### PR TITLE
Say eight languages, not nine

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -6,7 +6,7 @@ primary design constraint and everything below is subordinate to it.
 
 **Status:** FluidAudio only — sherpa-onnx removed (§13). Silero VAD in (§17).
 First-run download is visible and interruptible (§18); default is Multilingual,
-auto-detecting. Per-app capture actually switches as of §19; nine languages, §20.
+auto-detecting. Per-app capture actually switches as of §19; eight languages, §20.
 The menu bar badge says what is actually happening (§21).
 Phase 3 complete, published to a repo.
 Remaining before this is shippable: stable signing identity, real-world WER,

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Bump `VERSION` (and `BUILD`, which must only ever increase) at the top of
 - **Multilingual on auto-detect** is the default. The EOU variants are the ones
   measured; Nemotron 1120 / 2240 are wired but barely tested.
 - Non-English needs the **Multilingual** variant; the other six are English-only
-  checkpoints. Its nine languages are the ones exposed here — the model itself
+  checkpoints. Its eight languages are the ones exposed here — the model itself
   reaches ~40 via `prompt_id`, and adding one is a menu entry plus a FLEURS-style
   code.
 - Singing is speech as far as the VAD is concerned, so vocal music will be

--- a/app/macos/FluidAudioEngine.swift
+++ b/app/macos/FluidAudioEngine.swift
@@ -78,7 +78,7 @@ enum FluidVariant: String, CaseIterable {
         case .nemotron1120: return "612 MB · punctuated · the trained chunk size"
         case .nemotron2240: return "612 MB · punctuated · highest throughput"
         case .unified: return "595 MB · punctuated · 2.08 s · Nemotron is faster"
-        case .multilingual: return "583–633 MB · default · 9 languages · punctuated"
+        case .multilingual: return "583–633 MB · default · 8 languages · punctuated"
         }
     }
 


### PR DESCRIPTION
## What

Every surface that named a language count said nine. The app transcribes eight.

`FluidLanguage` exposes `en, es, fr, it, pt, de, zh, ja`. The ninth case is `auto`, which is a detection mode *over* those eight rather than a language of its own — the enum's own doc comment spells this out: the six Latin-script languages share the pruned pack, "while zh/ja — and `auto`, which must be able to decode anything" need the full one. 6 + 2 = 8.

## Changes

- `app/macos/FluidAudioEngine.swift` — the Multilingual menu subtitle, the only place the count was user-visible in the app: `9 languages` → `8 languages`
- `README.md` — "Its nine languages are the ones exposed here" → eight
- `PLAN.md` — the status line

## Verification

`swift build` passes. `grep` for the count across the repo comes back clean.

The site and the GitHub repo description carried the same claim; both are updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)